### PR TITLE
Add course button and functionality

### DIFF
--- a/react_app/src/actions/index.js
+++ b/react_app/src/actions/index.js
@@ -1,4 +1,4 @@
-import store from "../reducers/index";
+// import store from "../reducers/index";
 
 // example of an action
 export const increment = (amount) => {
@@ -76,5 +76,33 @@ export const fetchCourses = () => {
 					dispatch(fetched_courses(data))}
       )
       .catch(err => console.log(err));
+  };
+};
+
+export const added_Courses = (name, desc) => {
+	return {
+		type: 'ADDED_COURSE',
+		payload: {desc: desc, _id:name}
+	};
+};
+
+export const addCourse = (name, desc) => {
+  return function(dispatch, getState) {
+    return fetch(`http://localhost:9000/courses`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				description: desc,
+				_id: name,
+        overall_rating: '*'
+			})
+		})
+		      .then((responseJson) => {
+            dispatch(added_Courses(name, desc))
+		        return responseJson.success;
+		      })
+		      .catch((error) => {
+		        console.error(error);
+		      });
   };
 };

--- a/react_app/src/components/HomePage/AddCourseFormDialog.js
+++ b/react_app/src/components/HomePage/AddCourseFormDialog.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import {connect} from 'react-redux';
+import {addCourse} from '../../actions';
+
+function AddCourseFormDialog(props) {
+  const [open, setOpen] = React.useState(false);
+  let courseName = '';
+  let courseDesc = '';
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleSubmit = (courseName, courseDescription) => {
+
+    props.dispatch(addCourse(courseName, courseDescription));
+    setOpen(false);
+    window.location.reload();
+  };
+
+  return (
+    <div>
+      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+        Add a Course
+      </Button>
+      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+        <DialogTitle id="form-dialog-title">Add Course</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            To add course, please enter details below:
+          </DialogContentText>
+          <TextField
+            autoFocus
+            required
+            margin="dense"
+            id="course_id"
+            label="CourseName"
+            onInput={ e=>courseName = e.target.value}
+            fullWidth
+          />
+          <TextField
+            required
+            margin="dense"
+            id="course_description"
+            label="Description"
+            onInput={ e=>courseDesc = e.target.value}
+            fullWidth
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary">
+            Cancel
+          </Button>
+          <Button onClick={() => handleSubmit(courseName, courseDesc)} color="primary">
+            Submit
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+const mapStateToProps = (state) => {
+    return {courseList: state.courseList};
+}
+
+export default connect(mapStateToProps)(AddCourseFormDialog);

--- a/react_app/src/components/HomePage/CourseItemList.js
+++ b/react_app/src/components/HomePage/CourseItemList.js
@@ -1,19 +1,19 @@
 import React from 'react';
 import CourseItem from './CourseItem';
+import AddCourseFormDialog from './AddCourseFormDialog';
 import {connect} from 'react-redux';
 import {deleteMessage, deleteAllMessages, editMessage, editRating1, editRating2,
    editRating3, editRating4, editRating5, fetchCourses} from '../../actions';
-
 import Button from "@material-ui/core/Button";
 
 class CourseItemList extends React.Component {
 
   componentDidMount() {
           this.props.dispatch(fetchCourses());
-      }
-
+      };
 
     render() {
+
         return (<div className="reviewedCourses">
             <div className="courseListHeader content">
                 <p>Reviewed Courses</p>
@@ -21,7 +21,6 @@ class CourseItemList extends React.Component {
                     <Button variant="outlined">Filter</Button>
                 </div>
             </div>
-
             <div className="courseList">
                 {
                     Object.values(this.props.courseList).map((course, index) => {
@@ -30,17 +29,19 @@ class CourseItemList extends React.Component {
                             courseNumber={course._id}
                             rating={course.overall_rating}
                             review={course.description}
-   
                         />;
                     })
                 }
             </div>
+            <div>
+            <AddCourseFormDialog/>
+            </div>
         </div>);
     }
 }
+
 const mapStateToProps = (state) => {
     return {courseList: state.courseList};
 }
 
 export default connect(mapStateToProps)(CourseItemList);
-

--- a/react_app/src/components/HomePage/HomePage.css
+++ b/react_app/src/components/HomePage/HomePage.css
@@ -9,7 +9,7 @@
 
 @media screen and (max-width: 950px) {
     .content{
-        width: 90%;
+        width: 90%; 
     }
 }
 
@@ -61,3 +61,7 @@
     padding-right: 15px;
     float: right;
 }
+
+
+
+

--- a/react_app/src/components/HomePage/HomePage.css
+++ b/react_app/src/components/HomePage/HomePage.css
@@ -9,7 +9,7 @@
 
 @media screen and (max-width: 950px) {
     .content{
-        width: 90%; 
+        width: 90%;
     }
 }
 
@@ -61,7 +61,3 @@
     padding-right: 15px;
     float: right;
 }
-
-
-
-

--- a/react_app/src/reducers/index.js
+++ b/react_app/src/reducers/index.js
@@ -16,7 +16,6 @@ const courseReducer = (courseList = default_data, action) => {
     let copy = Object.assign({}, courseList);
     delete copy[action.payload];
     return copy;
-
   }
   if (action.type === 'DELETE_ALL_MESSAGES') {
     courseList = {};
@@ -48,6 +47,11 @@ const courseReducer = (courseList = default_data, action) => {
     return copy;
   }
     if (action.type === 'FETCHED_COURSES') {
+      return Object.assign({}, courseList,
+        action.data
+      );
+    }
+    if (action.type === 'ADDED_COURSE') {
       return Object.assign({}, courseList,
         action.data
       );


### PR DESCRIPTION
Included an "Add Course" button on the home page for add course functionality with a POST request to the mongo db.
I know we talked about only allowing admin user to a add course, but we can add more conditions once we have the login/user functionality in. 

The dialog/code can also be used for add ratings and add users etc similar type of actions.
The validation of the input fields will need to be added as a next step.  I'm also planning to add a confirmation msg as well.
Location of the button also likely to be changed to top of the page.
Currently there are no ratings for new course added, we can decide what the default over all rating should be.

Wanted to show you all before moving further!

![image](https://user-images.githubusercontent.com/10429026/86048029-d941af80-ba1d-11ea-90f4-282e4550ea1f.png)
