### PR TITLE
Changed default rating when adding course

### DIFF
--- a/react_app/src/actions/index.js
+++ b/react_app/src/actions/index.js
@@ -86,7 +86,7 @@ export const addCourse = (name, desc) => {
             body: JSON.stringify({
                 description: desc,
                 _id: name,
-                overall_rating: '*'
+                overall_rating: '-'
             })
         })
             .then((responseJson) => {


### PR DESCRIPTION
Team agreed to change default rating when adding course from "*" to "-", instead of requiring user to input rating.