### PR TITLE
role based access control for add and delete courses

### DIFF
--- a/facebook-setup.js
+++ b/facebook-setup.js
@@ -17,7 +17,8 @@ const currentUser = await User.findOne({
 if (!currentUser) {
 	const newUser = await new User({
 		_id: profile.id,
-		displayName: profile.displayName
+		displayName: profile.displayName,
+		role: 'Customer'
 	}).save();
 	if (newUser) {
 		done(null, newUser);

--- a/google-setup.js
+++ b/google-setup.js
@@ -18,7 +18,8 @@ async (token, tokenSecret, profile, done) => {
   if (!currentUser) {
     const newUser = await new User({
       _id: profile.id,
-      displayName: profile.displayName
+      displayName: profile.displayName,
+      role: 'Customer'
     }).save();
     if (newUser) {
       done(null, newUser);

--- a/models/user.js
+++ b/models/user.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose')
 const messageSchema = mongoose.Schema({
   _id: String,
   displayName: String,
+  role: String
 })
 
 module.exports = mongoose.model('User', messageSchema, 'Users')

--- a/react_app/src/actions/index.js
+++ b/react_app/src/actions/index.js
@@ -114,11 +114,11 @@ export const executeSearch = () => {
             .then(
                 data => data.json())
             .then(data => {
-                    dispatch(change_page_count(data['pageCount'])) 
+                    dispatch(change_page_count(data['pageCount']))
                     dispatch(fetched_courses(data['data']))
                 }
             )
-            .catch(err => console.log(err)); 
+            .catch(err => console.log(err));
         */
     }
 }
@@ -170,8 +170,8 @@ export const addReview = (review, rating, courseId) => {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({
-                Course_id: courseId, 
-                Rating: rating, 
+                Course_id: courseId,
+                Rating: rating,
                 Comments: review
             }),
             credentials: 'include'
@@ -198,7 +198,7 @@ export const checkStatus = () => {
         .catch(err => {
             let payload = {
                 isAuthenticated: false,
-                user: null,
+                user: null
             }
             dispatch(authenticated(payload));
         })

--- a/react_app/src/components/HomePage/AddCourseFormDialog.js
+++ b/react_app/src/components/HomePage/AddCourseFormDialog.js
@@ -23,16 +23,22 @@ function AddCourseFormDialog(props) {
     setOpen(false);
   };
 
-  const handleAdminSubmit = (courseName, courseDescription) => {
+  const handleSubmit = (courseName, courseDescription) => {
 
+      props.dispatch(addCourse(courseName, courseDescription));
+      setOpen(false);
+      window.location.reload();
+    };
+
+
+  const handleAdminSubmit = (courseName, courseDescription) => {
     props.dispatch(addCourse(courseName, courseDescription));
-    props.dispatch(checkStatus());
     setOpen(false);
     window.location.reload();
   };
 
   const handleCustomerSubmit = (courseName, courseDescription) => {
-    props.dispatch(checkStatus());
+    // props.dispatch(checkStatus());
     setOpen(false);
     window.alert('This is a customer submission TODO: send email with Add-course info to admins.')
   };
@@ -47,7 +53,7 @@ if (userRole === 'Admin') {
         <DialogTitle id="form-dialog-title">Add Course</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            To add course, please enter details below:
+            ADMIN: To add course, please enter details below:
           </DialogContentText>
           <TextField
             autoFocus
@@ -71,7 +77,7 @@ if (userRole === 'Admin') {
           <Button onClick={handleClose} color="primary">
             Cancel
           </Button>
-          <Button onClick={() => handleAdminSubmit(courseName, courseDesc)} color="primary">
+          <Button onClick={() => handleSubmit(courseName, courseDesc)} color="primary">
             Submit
           </Button>
         </DialogActions>
@@ -88,7 +94,7 @@ if (userRole === 'Admin') {
         <DialogTitle id="form-dialog-title">Add Course</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            CUSTOMER: To add course, please enter details below:
+            Don't see the course you're looking for? Send us the course details and we'll add it for you!
           </DialogContentText>
           <TextField
             autoFocus
@@ -113,7 +119,7 @@ if (userRole === 'Admin') {
             Cancel
           </Button>
           <Button onClick={() => handleCustomerSubmit(courseName, courseDesc)} color="primary">
-            Submit
+            Send to Admins
           </Button>
         </DialogActions>
       </Dialog>

--- a/react_app/src/components/HomePage/AddCourseFormDialog.js
+++ b/react_app/src/components/HomePage/AddCourseFormDialog.js
@@ -7,7 +7,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import {connect} from 'react-redux';
-import {addCourse, checkStatus} from '../../actions';
+import {addCourse} from '../../actions';
 
 function AddCourseFormDialog(props) {
   const [open, setOpen] = React.useState(false);
@@ -23,24 +23,15 @@ function AddCourseFormDialog(props) {
     setOpen(false);
   };
 
-  const handleSubmit = (courseName, courseDescription) => {
-
+  const handleAdminSubmit = (courseName, courseDescription) => {
       props.dispatch(addCourse(courseName, courseDescription));
       setOpen(false);
       window.location.reload();
     };
 
-
-  const handleAdminSubmit = (courseName, courseDescription) => {
-    props.dispatch(addCourse(courseName, courseDescription));
-    setOpen(false);
-    window.location.reload();
-  };
-
   const handleCustomerSubmit = (courseName, courseDescription) => {
-    // props.dispatch(checkStatus());
     setOpen(false);
-    window.alert('This is a customer submission TODO: send email with Add-course info to admins.')
+    window.alert('TODO: send email with Add-course info to admins.')
   };
 
 if (userRole === 'Admin') {
@@ -53,7 +44,7 @@ if (userRole === 'Admin') {
         <DialogTitle id="form-dialog-title">Add Course</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            ADMIN: To add course, please enter details below:
+            For Admins: To add course, please enter details below:
           </DialogContentText>
           <TextField
             autoFocus
@@ -74,13 +65,13 @@ if (userRole === 'Admin') {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={() => handleSubmit(courseName, courseDesc)} color="primary">
-            Submit
-          </Button>
-        </DialogActions>
+            <Button onClick={handleClose} color="primary">
+              Cancel
+            </Button>
+            <Button onClick={() => handleAdminSubmit(courseName, courseDesc)} color="primary">
+              Submit
+            </Button>
+          </DialogActions>
       </Dialog>
     </div>
   );
@@ -135,4 +126,4 @@ const mapStateToProps = (state) => {
     }
 }
 
-export default connect(mapStateToProps, {checkStatus})(AddCourseFormDialog);
+export default connect(mapStateToProps)(AddCourseFormDialog);

--- a/react_app/src/components/HomePage/AddCourseFormDialog.js
+++ b/react_app/src/components/HomePage/AddCourseFormDialog.js
@@ -7,12 +7,13 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import {connect} from 'react-redux';
-import {addCourse} from '../../actions';
+import {addCourse, checkStatus, authenticated} from '../../actions';
 
 function AddCourseFormDialog(props) {
   const [open, setOpen] = React.useState(false);
   let courseName = '';
   let courseDesc = '';
+  let userRole = props.auth.user.role;
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -22,13 +23,21 @@ function AddCourseFormDialog(props) {
     setOpen(false);
   };
 
-  const handleSubmit = (courseName, courseDescription) => {
+  const handleAdminSubmit = (courseName, courseDescription) => {
 
     props.dispatch(addCourse(courseName, courseDescription));
+    props.dispatch(checkStatus());
     setOpen(false);
     window.location.reload();
   };
 
+  const handleCustomerSubmit = (courseName, courseDescription) => {
+    props.dispatch(checkStatus());
+    setOpen(false);
+    window.alert('This is a customer submission TODO: send email with Add-course info to admins.')
+  };
+
+if (userRole === 'Admin') {
   return (
     <div>
       <Button variant="outlined" color="primary" onClick={handleClickOpen}>
@@ -62,7 +71,48 @@ function AddCourseFormDialog(props) {
           <Button onClick={handleClose} color="primary">
             Cancel
           </Button>
-          <Button onClick={() => handleSubmit(courseName, courseDesc)} color="primary">
+          <Button onClick={() => handleAdminSubmit(courseName, courseDesc)} color="primary">
+            Submit
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+} else {
+  return (
+    <div>
+      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+        Add a Course
+      </Button>
+      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+        <DialogTitle id="form-dialog-title">Add Course</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            CUSTOMER: To add course, please enter details below:
+          </DialogContentText>
+          <TextField
+            autoFocus
+            required
+            margin="dense"
+            id="course_id"
+            label="CourseName"
+            onInput={ e=>courseName = e.target.value}
+            fullWidth
+          />
+          <TextField
+            required
+            margin="dense"
+            id="course_description"
+            label="Description"
+            onInput={ e=>courseDesc = e.target.value}
+            fullWidth
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary">
+            Cancel
+          </Button>
+          <Button onClick={() => handleCustomerSubmit(courseName, courseDesc)} color="primary">
             Submit
           </Button>
         </DialogActions>
@@ -70,9 +120,13 @@ function AddCourseFormDialog(props) {
     </div>
   );
 }
-
-const mapStateToProps = (state) => {
-    return {courseList: state.courseList};
 }
 
-export default connect(mapStateToProps)(AddCourseFormDialog);
+const mapStateToProps = (state) => {
+    return {
+      courseList: state.courseList,
+      auth: state.auth
+    }
+}
+
+export default connect(mapStateToProps, {checkStatus})(AddCourseFormDialog);

--- a/react_app/src/components/HomePage/AddCourseFormDialog.js
+++ b/react_app/src/components/HomePage/AddCourseFormDialog.js
@@ -13,7 +13,7 @@ function AddCourseFormDialog(props) {
   const [open, setOpen] = React.useState(false);
   let courseName = '';
   let courseDesc = '';
-  let userRole = props.auth.user.role;
+  let userRole = props.auth.userRole;
 
   const handleClickOpen = () => {
     setOpen(true);

--- a/react_app/src/components/HomePage/AddCourseFormDialog.js
+++ b/react_app/src/components/HomePage/AddCourseFormDialog.js
@@ -34,7 +34,6 @@ function AddCourseFormDialog(props) {
     window.alert('TODO: send email with Add-course info to admins.')
   };
 
-if (userRole === 'Admin') {
   return (
     <div>
       <Button variant="outlined" color="primary" onClick={handleClickOpen}>
@@ -43,81 +42,56 @@ if (userRole === 'Admin') {
       <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
         <DialogTitle id="form-dialog-title">Add Course</DialogTitle>
         <DialogContent>
-          <DialogContentText>
-            For Admins: To add course, please enter details below:
-          </DialogContentText>
-          <TextField
-            autoFocus
-            required
-            margin="dense"
-            id="course_id"
-            label="CourseName"
-            onInput={ e=>courseName = e.target.value}
-            fullWidth
-          />
-          <TextField
-            required
-            margin="dense"
-            id="course_description"
-            label="Description"
-            onInput={ e=>courseDesc = e.target.value}
-            fullWidth
-          />
+
+            {userRole === 'Admin' ?
+            <DialogContentText>
+                For Admins: To add course, please enter details below
+            </DialogContentText> :
+            <DialogContentText>
+                Don't see the course you're looking for? Send us the course details and we'll add it for you!
+            </DialogContentText>}
+
+            <TextField
+              autoFocus
+              required
+              margin="dense"
+              id="course_id"
+              label="CourseName"
+              onInput={ e=>courseName = e.target.value}
+              fullWidth
+            />
+            <TextField
+              required
+              margin="dense"
+              id="course_description"
+              label="Description"
+              onInput={ e=>courseDesc = e.target.value}
+              fullWidth
+            />
+
         </DialogContent>
         <DialogActions>
-            <Button onClick={handleClose} color="primary">
-              Cancel
-            </Button>
-            <Button onClick={() => handleAdminSubmit(courseName, courseDesc)} color="primary">
-              Submit
-            </Button>
-          </DialogActions>
-      </Dialog>
-    </div>
-  );
-} else {
-  return (
-    <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
-        Add a Course
-      </Button>
-      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
-        <DialogTitle id="form-dialog-title">Add Course</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Don't see the course you're looking for? Send us the course details and we'll add it for you!
-          </DialogContentText>
-          <TextField
-            autoFocus
-            required
-            margin="dense"
-            id="course_id"
-            label="CourseName"
-            onInput={ e=>courseName = e.target.value}
-            fullWidth
-          />
-          <TextField
-            required
-            margin="dense"
-            id="course_description"
-            label="Description"
-            onInput={ e=>courseDesc = e.target.value}
-            fullWidth
-          />
-        </DialogContent>
-        <DialogActions>
+
           <Button onClick={handleClose} color="primary">
             Cancel
           </Button>
-          <Button onClick={() => handleCustomerSubmit(courseName, courseDesc)} color="primary">
-            Send to Admins
-          </Button>
+
+          {userRole === 'Admin' ?
+          <Button
+            onClick={() => handleAdminSubmit(courseName, courseDesc)} color="primary">
+              Submit
+          </Button> :
+          <Button
+            onClick={() => handleCustomerSubmit(courseName, courseDesc)} color="primary">
+              Send to Admins
+          </Button>}
+
         </DialogActions>
       </Dialog>
     </div>
   );
 }
-}
+
 
 const mapStateToProps = (state) => {
     return {

--- a/react_app/src/components/HomePage/AddCourseFormDialog.js
+++ b/react_app/src/components/HomePage/AddCourseFormDialog.js
@@ -7,7 +7,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import {connect} from 'react-redux';
-import {addCourse, checkStatus, authenticated} from '../../actions';
+import {addCourse, checkStatus} from '../../actions';
 
 function AddCourseFormDialog(props) {
   const [open, setOpen] = React.useState(false);

--- a/react_app/src/components/HomePage/CourseItem.js
+++ b/react_app/src/components/HomePage/CourseItem.js
@@ -10,7 +10,8 @@ class CourseItem extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            courseNumber: this.props.courseNumber
+            courseNumber: this.props.courseNumber,
+            userRole: this.props.auth.userRole
         };
     }
 
@@ -49,27 +50,37 @@ class CourseItem extends React.Component {
                 </Box>
 
             </Box>
+
             <div className='courseItemVerticalSides'>
+
             <Box className='courseItemVerticalSides courseItemVerticalMiddle'
                  style={{paddingTop: '5px'}}
             >
                 <Typography variant='body2'>{this.props.date || 'N/A'}</Typography>
             </Box>
-            <div>
-                <IconButton aria-label="delete"
-                            className='courseItemVerticalSides courseItemVerticalMiddle'
-                            onClick={this.handleRemove.bind(this)}
-                >
-                    <DeleteIcon fontSize="small" />
-                </IconButton>
-            </div>
+
+            { this.props.auth.userRole === 'Admin' ?
+              <IconButton aria-label="delete"
+                          className='courseItemVerticalSides courseItemVerticalMiddle'
+                          onClick={this.handleRemove.bind(this)}>
+                  <DeleteIcon fontSize="small" />
+              </IconButton>
+              : null
+            }
+
             </div>
 
         </Box>;
     }
 }
 
+const mapStateToProps = (state) => {
+    return {
+      auth: state.auth
+    }
+}
+
 export default connect(
-    null,
+    (mapStateToProps),
     { deleteCourse }
 )(CourseItem)

--- a/react_app/src/reducers/authReducer.js
+++ b/react_app/src/reducers/authReducer.js
@@ -2,6 +2,7 @@
 const initialState = {
     isAuthenticated: false,
     user: null,
+    userRole: null
 }
 
 const authReducer = (state = initialState, action) => {

--- a/routes/auth-routes.js
+++ b/routes/auth-routes.js
@@ -17,14 +17,15 @@ router.get("/checkStatus", authCheck, (req, res) => {
   res.status(200).json({
     isAuthenticated: true,
     message: "user successfully authenticated",
-    user: req.user
+    user: req.user,
+    userRole: req.user.role
   });
 });
 
 router.get("/logout", (req, res) => {
   req.logout();
   res.status(200).json({
-    isAuthenticated: false, 
+    isAuthenticated: false,
     user: null,
   });
 });

--- a/routes/courses.js
+++ b/routes/courses.js
@@ -16,7 +16,7 @@ router.get('/', function (req, res, next) {
           Course.countDocuments()
             .then(count => {
               let pageCount = count % 10 === 0 ? Math.floor(count/10):  Math.floor(count/10) + 1;
-              package = { 
+              package = {
                 pageCount : pageCount,
                 data: docs};
               res.status(200).json(package);
@@ -46,27 +46,41 @@ router.get('/:courseId', function (req, res, next) {
 });
 
 router.post('/', function(req, res, next) {
-  const newCourse = new Course({
-      _id: req.body._id,
-overall_rating: req.body.overall_rating,
-description: req.body.description,
-num_reviews: req.body.num_reviews
-  })
-  newCourse.save().then(result => {
-    console.log(result);
-  })
-  .catch(err => console.log(err));
+  if(req.user.role === 'Admin'){
+    const newCourse = new Course({
+        _id: req.body._id,
+        overall_rating: req.body.overall_rating,
+        description: req.body.description,
+        num_reviews: req.body.num_reviews
+    });
+
+    newCourse.save()
+    .then(result => {res.status(200).json(result);})
+    .catch(err => {
+      console.log(err);
+      console.log("COULD NOT ADD COURSE!")
+      res.status(500).json({
+        message: 'Server error. Unable to add review'
+      })
+    });
+
+  } else {
+    res.status(401).json({message: 'Unauthorized user'});
+  }
 });
 
 router.delete('/:courseId', function(req, res, next) {
-  const courseId = req.params.courseId
-  Course.deleteOne({'_id': courseId}, function(err) {
-            if (err) {
-                console.log(err)
-            } else {
-                res.send('deleted course with id :  ' + courseId);
-            }})
+  const courseId = req.params.courseId;
+  if (req.user.role === 'Admin'){
+    Course.deleteOne({'_id': courseId}, function(err) {
+      if (err) {
+          console.log(err)
+      } else {
+          res.send('deleted course with id :  ' + courseId);
+      }})
+  } else {
+    res.status(401).json({message: 'Unauthorized user'});
+  }
 });
-
 
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -37,6 +37,7 @@ router.post('/', function(req, res, next) {
   const newUser = new User({
       _id: req.body._id,
       displayName: req.body.displayName,
+      role: 'Customer'
   })
   newUser.save().then(result => {
     console.log(result);


### PR DESCRIPTION
Implemented role based access control for adding and deleting courses wherein only if a user has the role of 'Admin' can they directly delete a course by clicking the delete icon/add a course to the CourseList upon clicking 'Submit' from the Add-Course-Dialog-Form. If the user has a role of 'Customer', then the delete course icon is not rendered and when they click on 'Send Email' from the Add-Course-Dialog-Form - an email should be sent to the admin email address: coursehub436@gmail.com (I have not yet implemented this email functionality). 

I've set up coursehub436@gmail.com (password: cpsc436Icoursehub!) to be the only user with Admin role currently. So if you'd like to test the admin role based access then you'll need to login via google with these credentials. 